### PR TITLE
Update lucky dependency

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,4 +11,4 @@ license: MIT
 dependencies:
   lucky:
     github: luckyframework/lucky
-    branch: master
+    version: ~> 0.27.0


### PR DESCRIPTION
Change lucky dependency to "~> 0.27.0" to match up with current lucky version dependencies. Fixes issue:

```
  Unable to satisfy the following requirements:

  - `lucky (~> 0.27.0)` required by `shard.yml`
  - `lucky (~> 0.27.0)` required by `authentic 0.7.3`
  - `lucky (branch master)` required by `lucky_subdomain 0.1.0+git.commit.499bb1b89efe94989c41175823849c6d2cc1a5e3`
  Failed to resolve dependencies
```